### PR TITLE
Add a getter and prevent shelf alignment from picking sizes that are larger than the atlas.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "etagere"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "euclid",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "etagere"
 description = "Dynamic 2D texture atlas allocation using the shelf packing algorithm."
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/etagere"
 documentation = "https://docs.rs/etagere/"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ atlas.deallocate(a.id);
 
 let c = atlas.allocate(size2(300, 200)).unwrap();
 
-assert_eq!(c.rectangle, atlas[c.id]);
+assert_eq!(c.rectangle, atlas.get(c.id));
 
 atlas.deallocate(c.id);
 atlas.deallocate(b.id);


### PR DESCRIPTION
I couldn't implement `Index` because the rectangle has to be computed, so `.get` will do.

Fixes #17 