### PR TITLE
Fix integer overflow in free_space function

### DIFF
--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -235,7 +235,7 @@ impl BucketedAtlasAllocator {
 
     /// How much space is available for future allocations.
     pub fn free_space(&self) -> i32 {
-        (self.width * self.height) as i32 - self.allocated_space
+        (self.width as i32 * self.height as i32) - self.allocated_space
     }
 
     fn alloc_from_bucket(&mut self, shelf_index: usize, bucket_index: BucketIndex, width: u16) -> Option<Allocation> {


### PR DESCRIPTION
This overflows when the atlas area exceeds `65535`, which is... Not much