### PR TITLE
Use correct first bucket during `grow`

### DIFF
--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -850,13 +850,13 @@ fn grow_horizontally() {
 
     // Not enough space left in existing shelves and above.
     // even coalescing is not sufficient.
-    assert!(atlas.allocate(size2(70, 70)).is_none());
+    assert!(atlas.allocate(size2(512, 32)).is_none());
 
     // Grow just enough horizontally to add more buckets
     atlas.grow(size2(256 * 2, 256));
 
     // Allocation should succeed now
-    assert!(atlas.allocate(size2(70, 70)).is_some());
+    assert!(atlas.allocate(size2(512, 32)).is_some());
 }
 
 #[test]

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -164,11 +164,10 @@ impl BucketedAtlasAllocator {
                 let bucket_width = shelf.bucket_width;
 
                 let max_new_buckets = (MAX_BIN_COUNT - self.buckets.len()) as u16;
-                let last_bucket_on_shelf = BucketIndex(((self.column_width / bucket_width) as u16).saturating_sub(1));
                 let mut num_buckets_to_add = additional_width / bucket_width;
                 num_buckets_to_add = num_buckets_to_add.min(max_new_buckets);
 
-                let mut bucket_next = last_bucket_on_shelf;
+                let mut bucket_next = shelf.first_bucket;
 
                 for _ in 0..num_buckets_to_add {
                     let bucket = Bucket {


### PR DESCRIPTION
Fixes a regression caused by using the wrong next bucket in #27 Confirmed to work with iced's `tour` example.

I think this is correct but it would be helpful if anyone could double check the `first_bucket` logic here.

Also updated the `grow_horizontally` example to avoid the allocation failing after resize because of shelf height. I'd like to double check that this expectation change is ok with @hecrj before merging.