### PR TITLE
Speed up allocation by traversing only unallocated items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "etagere"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "euclid",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "etagere"
 description = "Dynamic 2D texture atlas allocation using the shelf packing algorithm."
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/etagere"
 documentation = "https://docs.rs/etagere/"


### PR DESCRIPTION
It makes allocating from large-ish mostly full altases much faster (20 times faster with a recorded workload that was making glyph cache allocation very slow in Firefox).