### PR TITLE
Fix file_name type in etagere_atlas_allocator_dump_svg in ffi

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn etagere_atlas_allocator_get(allocator: &AtlasAllocator,
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn etagere_atlas_allocator_dump_svg(allocator: &AtlasAllocator, file_name: *const i8) -> EtagereStatus {
+pub unsafe extern "C" fn etagere_atlas_allocator_dump_svg(allocator: &AtlasAllocator, file_name: *const std::os::raw::c_char) -> EtagereStatus {
     let cstr = std::ffi::CStr::from_ptr(file_name);
     let rstr = String::from_utf8_lossy(cstr.to_bytes());
     let mut file = match std::fs::File::create(rstr.as_ref()) {


### PR DESCRIPTION
It's not safe to use i8 directly as a replacement for c_char, because on some platforms, c_char may actually be u8, thus causing build failures.