### PR TITLE
Only consider bad fits if there are no candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "etagere"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "euclid",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "etagere"
 description = "Dynamic 2D texture atlas allocation using the shelf packing algorithm."
-version = "0.2.14"
+version = "0.2.15"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 repository = "https://github.com/nical/etagere"
 documentation = "https://docs.rs/etagere/"


### PR DESCRIPTION
I realized soon after publishing 0.2.14 that the change made it so  when searching available shelves, the algorithm would favor a bad fit (non-empty shelve with a lot of vertical space) over a taller empty shelf that could be split vertically (and not waste space).

This fixes it by only considering a bad fit if there is no shelf that can support the allocation.